### PR TITLE
Added play area modes "Viewport", "Manual", and "Infinite"

### DIFF
--- a/bullet_server.h
+++ b/bullet_server.h
@@ -10,6 +10,14 @@
 class BulletServer : public Node2D {
 	GDCLASS(BulletServer, Node2D);
 
+public:
+	enum AreaMode {
+		VIEWPORT,
+		MANUAL,
+		INFINITE,
+	};
+
+private:
 	int bullet_pool_size;
 
 	bool pop_on_collide;
@@ -18,7 +26,8 @@ class BulletServer : public Node2D {
 	Vector<Bullet *> live_bullets;
 	Vector<Bullet *> dead_bullets;
 
-	Rect2 play_area;
+	AreaMode play_area_mode;
+	Rect2 play_area_rect;
 	float play_area_margin;
 	bool play_area_allow_incoming;
 
@@ -33,8 +42,8 @@ class BulletServer : public Node2D {
 
 protected:
 	static void _bind_methods();
-
 	void _notification(int p_what);
+	void _validate_property(PropertyInfo &property) const;
 
 public:
 	BulletServer();
@@ -54,6 +63,12 @@ public:
 	void set_max_lifetime(float p_time);
 	float get_max_lifetime() const;
 
+	void set_play_area_mode(AreaMode p_mode);
+	AreaMode get_play_area_mode() const;
+
+	void set_play_area_rect(const Rect2 &p_rect);
+	Rect2 get_play_area_rect() const;
+
 	void set_play_area_margin(float p_margin);
 	float get_play_area_margin() const;
 
@@ -63,5 +78,7 @@ public:
 	void set_relay_autoconnect(bool p_enabled);
 	bool get_relay_autoconnect() const;
 };
+
+VARIANT_ENUM_CAST(BulletServer::AreaMode)
 
 #endif

--- a/doc_classes/BulletServer.xml
+++ b/doc_classes/BulletServer.xml
@@ -61,6 +61,15 @@
 		<member name="play_area_margin" type="float" setter="set_play_area_margin" getter="get_play_area_margin" default="0.0">
 			The distance, in pixels, bullets controlled by this server can travel outside the the current [Viewport] before being popped. Can be negative.
 		</member>
+		<member name="play_area_mode" type="int" setter="set_play_area_mode" getter="get_play_area_mode" enum="BulletServer.AreaMode" default="0">
+			The current mode used to define the play area's limits.
+			[code]VIEWPORT[/code] causes the play area to automatically follow the current viewport, with a configurable margin.
+			[code]MANUAL[/code] allows the play area's [Rect2] to be defined directly.
+			[code]INFINITE[/code] causes the play area to become infinite, and no bullet will pop based on location. Some other form of cleanup routine, such as [code]max_lifetime[/code], is recommended in this mode for best performance.
+		</member>
+		<member name="play_area_rect" type="Rect2" setter="set_play_area_rect" getter="get_play_area_rect" default="Rect2( 0, 0, 0, 0 )">
+			The [Rect2] definining the limits for active bullets in the server. Any bullet outside of this rectangle on physics process may be automatically popped, depending on configuration.
+		</member>
 		<member name="pop_on_collide" type="bool" setter="set_pop_on_collide" getter="get_pop_on_collide" default="true">
 			If [code]true[/code], bullets will be popped automatically if the server determines they have collided.
 			Disable if you're implementing more nuanced bullet behaviour on collision, like reflection.
@@ -83,5 +92,11 @@
 		</signal>
 	</signals>
 	<constants>
+		<constant name="VIEWPORT" value="0" enum="AreaMode">
+		</constant>
+		<constant name="MANUAL" value="1" enum="AreaMode">
+		</constant>
+		<constant name="INFINITE" value="2" enum="AreaMode">
+		</constant>
 	</constants>
 </class>

--- a/doc_classes/BulletServerRelay.xml
+++ b/doc_classes/BulletServerRelay.xml
@@ -55,7 +55,7 @@
 		<signal name="volley_spawn_requested">
 			<argument index="0" name="type" type="BulletType">
 			</argument>
-			<argument index="1" name="origin" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<argument index="2" name="shots" type="Array">
 			</argument>

--- a/doc_classes/BulletSpawner.xml
+++ b/doc_classes/BulletSpawner.xml
@@ -11,6 +11,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="can_fire" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if this spawner is not in the editor, in the scene tree, and has a valid [code]bullet_type[/code].
+			</description>
+		</method>
 		<method name="fire">
 			<return type="void">
 			</return>

--- a/doc_classes/BulletType.xml
+++ b/doc_classes/BulletType.xml
@@ -12,7 +12,13 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="0">
+		<member name="collision_detect_areas" type="bool" setter="set_collision_detect_areas" getter="get_collision_detect_areas" default="true">
+			If [code]true[/code], this type of bullet will scan for areas in its collision checks.
+		</member>
+		<member name="collision_detect_bodies" type="bool" setter="set_collision_detect_bodies" getter="get_collision_detect_bodies" default="true">
+			If [code]true[/code], this type of bullet will scan for bodies in its collision checks.
+		</member>
+		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
 			The physics layers to scan for determining collision detection with this type of bullet.
 		</member>
 		<member name="collision_shape" type="Shape2D" setter="set_collision_shape" getter="get_collision_shape">
@@ -35,7 +41,7 @@
 			The amplitude of this type of bullet's parallel offset wave.
 			Measured in pixels, and determines the maximum distance this type of bullet will be displaced along its trajectory by the parallel offset wave.
 		</member>
-		<member name="h_wave_frequency" type="float" setter="set_h_wave_frequency" getter="get_h_wave_frequency" default="0.0">
+		<member name="h_wave_frequency" type="float" setter="set_h_wave_frequency" getter="get_h_wave_frequency" default="1.4013e-45">
 			The frequency of this type of bullet's parallel offset wave.
 			Measured in Hz, and determines how many times per second the parallel offset wave will repeat.
 		</member>
@@ -83,7 +89,7 @@
 			The frequency of this type of bullet's perpendicular offset wave.
 			Measured in Hz, and determines how many times per second the perpendicular offset wave will repeat.
 		</member>
-		<member name="v_wave_type" type="int" setter="set_v_wave_type" getter="get_v_wave_type" enum="BulletType.WaveType" default="1">
+		<member name="v_wave_type" type="int" setter="set_v_wave_type" getter="get_v_wave_type" enum="BulletType.WaveType" default="0">
 			The wave type applied to this type of bullet's perpendicular offset.
 		</member>
 	</members>


### PR DESCRIPTION
BulletServer now has three modes for controlling its play area:
- `Viewport`, the default, follows the current viewport and can be expanded/contracted with a margin.
- `Manual` allows the the play area to be manipulated directly as a Rect2.
- `Infinite` basically turns off any form of location-based bullet culling.

Implements #10 