### PR TITLE
added mode check to _update_play_area

### DIFF
--- a/bullet_server.cpp
+++ b/bullet_server.cpp
@@ -35,9 +35,7 @@ void BulletServer::_notification(int p_what) {
 			if (Engine::get_singleton()->is_editor_hint()) {
 				return;
 			}
-			if (play_area_mode == VIEWPORT){
 			_update_play_area();
-			}
 			_process_bullets(get_physics_process_delta_time());
 		}
 		break;
@@ -109,6 +107,9 @@ void BulletServer::_create_bullet() {
 }
 
 void BulletServer::_update_play_area(){
+	if (play_area_mode != VIEWPORT){
+		return;
+	}
 	Transform2D canvas_transform = get_canvas_transform();
 	Vector2 view_pos = -canvas_transform.get_origin() / canvas_transform.get_scale();
 	Vector2 view_size = get_viewport_rect().size / canvas_transform.get_scale();


### PR DESCRIPTION
When initially setting up play area modes for BulletSpawner, I did not check what mode was currently set from within the `_update_play_area` method, and instead relied on the calling function checking the mode first. This meant that if the check was forgotten, the function could still be called and update the play area to match the viewport, even in manual mode.

I've simply added a conditional return to the function, so it only makes changes in Viewport mode.

Fixes #12 