### PR TITLE
Add live bullet accessors

### DIFF
--- a/bullet.cpp
+++ b/bullet.cpp
@@ -3,16 +3,16 @@
 void Bullet::spawn(const Ref<BulletType> &p_type, const Vector2 &p_position, const Vector2 &p_direction) {
 	time = 0.0;
 	rotation = 0.0;
-    _popped = false;
+  _popped = false;
 	_offset = Vector2(0, 0);
-    set_type(p_type);
-    set_position(p_position);
-    set_direction(p_direction);
+  set_type(p_type);
+  set_position(p_position);
+  set_direction(p_direction);
 	VS::get_singleton()->canvas_item_set_visible(ci_rid, true);
 }
 
 void Bullet::update(float delta) {
-    float current_speed = type->get_speed() + type->get_linear_acceleration() * time;
+  float current_speed = type->get_speed() + type->get_linear_acceleration() * time;
 	set_direction(direction.rotated(Math::deg2rad(type->get_curve_rate()) * delta));
 	position += direction * current_speed * delta;
 	_update_offset();
@@ -23,12 +23,12 @@ void Bullet::update(float delta) {
 }
 
 void Bullet::pop() {
-    _popped = true;
+  _popped = true;
 	VS::get_singleton()->canvas_item_set_visible(ci_rid, false);
 }
 
 bool Bullet::is_popped() {
-    return _popped;
+  return _popped;
 }
 
 bool Bullet::can_collide() {
@@ -40,12 +40,12 @@ void Bullet::_update_offset(){
 	Vector2 h_offset;
 	Vector2 v_offset;
 	Vector2 perpendicular = direction.rotated(Math_PI / 2);
-	
+
 	switch (type->get_h_wave_type()){
 		case BulletType::WaveType::SIN:
 			h_offset = direction * type->get_h_wave_amplitude() * sin(time * 2 * Math_PI * type->get_h_wave_frequency());
 			break;
-		
+
 		case BulletType::WaveType::COS:
 			h_offset = direction * type->get_h_wave_amplitude() * (cos(time * 2 * Math_PI * type->get_h_wave_frequency()) - 1);
 			break;
@@ -59,7 +59,7 @@ void Bullet::_update_offset(){
 		case BulletType::WaveType::SIN:
 			v_offset = perpendicular * type->get_v_wave_amplitude() * sin(time * 2 * Math_PI * type->get_v_wave_frequency());
 			break;
-		
+
 		case BulletType::WaveType::COS:
 			v_offset = perpendicular * type->get_v_wave_amplitude() * (cos(time * 2 * Math_PI * type->get_v_wave_frequency()) - 1);
 			break;
@@ -74,47 +74,47 @@ void Bullet::_update_offset(){
 }
 
 void Bullet::set_time(float p_time) {
-	time = p_time;    
+	time = p_time;
 }
 
 float Bullet::get_time() const {
-    return time;
+  return time;
 }
 
 void Bullet::set_type(const Ref<BulletType> &p_type) {
 	_update_appearance(p_type);
-    type = p_type;
+  type = p_type;
 }
 
 Ref<BulletType> Bullet::get_type() const {
-    return type;
+  return type;
 }
 
 void Bullet::set_direction(const Vector2 &p_direction) {
-    direction = p_direction;
+  direction = p_direction;
 	if (type.is_valid() && type->get_face_direction()){
 		rotation = p_direction.angle();
 	}
 }
 
 Vector2 Bullet::get_direction() const {
-    return direction;
+  return direction;
 }
 
 void Bullet::set_position(const Vector2 &p_position) {
-    position = p_position;
+  position = p_position;
 }
 
 Vector2 Bullet::get_position() const {
-    return position;
+  return position;
 }
 
 void Bullet::set_rotation(float p_radians) {
-    rotation = 0.0;
+  rotation = 0.0;
 }
 
 float Bullet::get_rotation() const {
-    return rotation;
+  return rotation;
 }
 
 Transform2D Bullet::get_transform(){
@@ -164,7 +164,7 @@ void Bullet::_bind_methods(){
 	ClassDB::bind_method(D_METHOD("is_popped"), &Bullet::is_popped);
 
 	ClassDB::bind_method(D_METHOD("can_collide"), &Bullet::can_collide);
-	
+
 	ClassDB::bind_method(D_METHOD("get_time"), &Bullet::get_time);
 
 	ClassDB::bind_method(D_METHOD("set_type", "type"), &Bullet::set_type);
@@ -186,7 +186,7 @@ void Bullet::_bind_methods(){
 
 Bullet::Bullet() {
 	ci_rid = VS::get_singleton()->canvas_item_create();
-    direction = Vector2(0,0);
+  direction = Vector2(0,0);
 }
 
 Bullet::~Bullet(){

--- a/bullet_server.cpp
+++ b/bullet_server.cpp
@@ -158,6 +158,14 @@ Array BulletServer::get_live_bullets() {
 	return bullets;
 }
 
+Array BulletServer::get_live_bullet_positions() {
+	Array bullet_positions;
+	for (int i = 0; i < live_bullets.size(); i++) {
+		bullet_positions.push_back(live_bullets[i]->get_position());
+	}
+	return bullet_positions;
+}
+
 void BulletServer::set_bullet_pool_size(int p_size) {
 	if (p_size > -1)
 		bullet_pool_size = p_size;
@@ -256,7 +264,9 @@ void BulletServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("spawn_volley", "type", "position", "volley"), &BulletServer::spawn_volley);
 	ClassDB::bind_method(D_METHOD("clear_bullets"), &BulletServer::clear_bullets);
 	ClassDB::bind_method(D_METHOD("get_bullet_count"), &BulletServer::get_bullet_count);
+
 	ClassDB::bind_method(D_METHOD("get_live_bullets"), &BulletServer::get_live_bullets);
+	ClassDB::bind_method(D_METHOD("get_live_bullet_positions"), &BulletServer::get_live_bullet_positions);
 
 	ClassDB::bind_method(D_METHOD("set_bullet_pool_size", "size"), &BulletServer::set_bullet_pool_size);
 	ClassDB::bind_method(D_METHOD("get_bullet_pool_size"), &BulletServer::get_bullet_pool_size);

--- a/bullet_server.cpp
+++ b/bullet_server.cpp
@@ -287,8 +287,8 @@ void BulletServer::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("collision_detected", PropertyInfo(Variant::OBJECT, "bullet", PROPERTY_HINT_RESOURCE_TYPE, "Bullet"), PropertyInfo(Variant::ARRAY, "colliders")));
 
 	BIND_ENUM_CONSTANT(VIEWPORT);
-    BIND_ENUM_CONSTANT(MANUAL);
-    BIND_ENUM_CONSTANT(INFINITE);
+  BIND_ENUM_CONSTANT(MANUAL);
+  BIND_ENUM_CONSTANT(INFINITE);
 }
 
 BulletServer::BulletServer() {

--- a/bullet_server.cpp
+++ b/bullet_server.cpp
@@ -140,14 +140,22 @@ void BulletServer::spawn_volley(const Ref<BulletType> &p_type, const Vector2 &p_
 	}
 }
 
-void BulletServer::clear_bullets(){
-	for (int i = 0; i < live_bullets.size(); i++){
+void BulletServer::clear_bullets() {
+	for (int i = 0; i < live_bullets.size(); i++) {
 		live_bullets[i]->pop();
 	}
 }
 
-int BulletServer::get_bullet_count(){
+int BulletServer::get_bullet_count() {
 	return live_bullets.size();
+}
+
+Array BulletServer::get_live_bullets() {
+	Array bullets;
+	for (int i = 0; i < live_bullets.size(); i++) {
+		bullets.push_back(live_bullets[i]);
+	}
+	return bullets;
 }
 
 void BulletServer::set_bullet_pool_size(int p_size) {
@@ -248,6 +256,7 @@ void BulletServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("spawn_volley", "type", "position", "volley"), &BulletServer::spawn_volley);
 	ClassDB::bind_method(D_METHOD("clear_bullets"), &BulletServer::clear_bullets);
 	ClassDB::bind_method(D_METHOD("get_bullet_count"), &BulletServer::get_bullet_count);
+	ClassDB::bind_method(D_METHOD("get_live_bullets"), &BulletServer::get_live_bullets);
 
 	ClassDB::bind_method(D_METHOD("set_bullet_pool_size", "size"), &BulletServer::set_bullet_pool_size);
 	ClassDB::bind_method(D_METHOD("get_bullet_pool_size"), &BulletServer::get_bullet_pool_size);

--- a/bullet_server.h
+++ b/bullet_server.h
@@ -54,6 +54,7 @@ public:
 
 	void clear_bullets();
 	int get_bullet_count();
+	Array get_live_bullets();
 
 	void set_bullet_pool_size(int p_size);
 	int get_bullet_pool_size() const;

--- a/bullet_server.h
+++ b/bullet_server.h
@@ -54,7 +54,9 @@ public:
 
 	void clear_bullets();
 	int get_bullet_count();
+
 	Array get_live_bullets();
+	Array get_live_bullet_positions();
 
 	void set_bullet_pool_size(int p_size);
 	int get_bullet_pool_size() const;

--- a/bullet_spawner.cpp
+++ b/bullet_spawner.cpp
@@ -2,776 +2,776 @@
 
 //"overrides"
 void BulletSpawner::_notification(int p_what) {
-    switch (p_what) {
+  switch (p_what) {
 
-		case NOTIFICATION_READY: {
-			set_notify_transform(true);
-            if (Engine::get_singleton()->is_editor_hint()){
-                set_physics_process(false);
-                return;
-            }
-            if (relay_autoconnect) {
-                BulletServerRelay *relay = Object::cast_to<BulletServerRelay>(Engine::get_singleton()->get_singleton_object("BulletServerRelay"));
-                connect("volley_fired", relay, "spawn_volley");
-            }
-            set_physics_process(true);
-            set_visible(preview_visible_in_game);
-		} break;
+  case NOTIFICATION_READY: {
+    set_notify_transform(true);
+      if (Engine::get_singleton()->is_editor_hint()){
+        set_physics_process(false);
+        return;
+      }
+      if (relay_autoconnect) {
+        BulletServerRelay *relay = Object::cast_to<BulletServerRelay>(Engine::get_singleton()->get_singleton_object("BulletServerRelay"));
+        connect("volley_fired", relay, "spawn_volley");
+      }
+      set_physics_process(true);
+      set_visible(preview_visible_in_game);
+  } break;
 
-		case NOTIFICATION_PHYSICS_PROCESS: {
-			if (Engine::get_singleton()->is_editor_hint()){
-                return;
-            }
-            if (autofire){
-                _autofire_time += get_physics_process_delta_time();
-                if (_autofire_time >= interval_frames / ProjectSettings::get_singleton()->get("physics/common/physics_fps").operator float()){
-                    fire();
-                    _autofire_time = 0;
-                }
-            }
-		} break;
-
-        case NOTIFICATION_TRANSFORM_CHANGED: {
-            if (aim_mode == TARGET_GLOBAL && get_global_transform().get_origin() != _previous_transform.get_origin()) {
-                _volley_change_notify();
-            } else if (get_global_transform().get_rotation() != _previous_transform.get_rotation()){
-                _volley_change_notify();
-            } else if (get_global_transform().get_scale() != _previous_transform.get_scale()){
-                _volley_change_notify();
-            }
-            _previous_transform = get_global_transform();
-        } break;
-
-        case NOTIFICATION_DRAW: {
-            if (is_visible_in_tree()){
-                _draw_preview(preview_color, preview_shot_color);
-            }
+  case NOTIFICATION_PHYSICS_PROCESS: {
+    if (Engine::get_singleton()->is_editor_hint()){
+        return;
+      }
+      if (autofire){
+        _autofire_time += get_physics_process_delta_time();
+        if (_autofire_time >= interval_frames / ProjectSettings::get_singleton()->get("physics/common/physics_fps").operator float()){
+          fire();
+          _autofire_time = 0;
         }
+      }
+  } break;
 
-		default:
-			break;
-	}
+    case NOTIFICATION_TRANSFORM_CHANGED: {
+      if (aim_mode == TARGET_GLOBAL && get_global_transform().get_origin() != _previous_transform.get_origin()) {
+        _volley_change_notify();
+      } else if (get_global_transform().get_rotation() != _previous_transform.get_rotation()){
+        _volley_change_notify();
+      } else if (get_global_transform().get_scale() != _previous_transform.get_scale()){
+        _volley_change_notify();
+      }
+      _previous_transform = get_global_transform();
+    } break;
+
+    case NOTIFICATION_DRAW: {
+      if (is_visible_in_tree()){
+        _draw_preview(preview_color, preview_shot_color);
+      }
+    }
+
+  default:
+    break;
+  }
 }
 
 //public functions
 bool BulletSpawner::can_fire() const {
-    return !Engine::get_singleton()->is_editor_hint() && is_inside_tree() && bullet_type.is_valid();
+  return !Engine::get_singleton()->is_editor_hint() && is_inside_tree() && bullet_type.is_valid();
 }
 
 void BulletSpawner::fire() {
-    if (!can_fire()){
-        return;
-    }
-    switch (pattern_mode)
-    {
-    case ALL: {
-        emit_signal("volley_fired", bullet_type->duplicate(), get_global_position(), get_scattered_volley());
-    } break;
+  if (!can_fire()){
+    return;
+  }
+  switch (pattern_mode)
+  {
+  case ALL: {
+    emit_signal("volley_fired", bullet_type->duplicate(), get_global_position(), get_scattered_volley());
+  } break;
 
-    case MANUAL: {
-        emit_signal("volley_fired", bullet_type->duplicate(), get_global_position(), _get_selected_shots(get_scattered_volley(), active_shot_indices));
-    } break;
+  case MANUAL: {
+    emit_signal("volley_fired", bullet_type->duplicate(), get_global_position(), _get_selected_shots(get_scattered_volley(), active_shot_indices));
+  } break;
 
-    default:
-        break;
-    }
+  default:
+    break;
+  }
 }
 
 void BulletSpawner::fire_shots(const PoolIntArray &p_shot_indices) {
-    if (!can_fire()){
-        return;
-    }
-    emit_signal("volley_fired", bullet_type->duplicate(), get_global_position(), _get_selected_shots(get_scattered_volley(), p_shot_indices));
+  if (!can_fire()){
+    return;
+  }
+  emit_signal("volley_fired", bullet_type->duplicate(), get_global_position(), _get_selected_shots(get_scattered_volley(), p_shot_indices));
 }
 
 Array BulletSpawner::get_volley() {
-    if (_volley_changed){
-        _cached_volley = _create_volley();
-        _volley_changed = false;
-    }
-    return _cached_volley;
+  if (_volley_changed){
+    _cached_volley = _create_volley();
+    _volley_changed = false;
+  }
+  return _cached_volley;
 }
 
 Array BulletSpawner::get_scattered_volley() {
-    if (scatter_mode == NONE || Math::is_zero_approx(scatter_range)){
-        return get_volley();
-    } 
+  if (scatter_mode == NONE || Math::is_zero_approx(scatter_range)){
+    return get_volley();
+  }
 
-    Array s_volley = get_volley().duplicate(true);
-    float rand_offset;
+  Array s_volley = get_volley().duplicate(true);
+  float rand_offset;
 
-    switch (scatter_mode)
-    {
-    case BULLET:
-        for (int i = 0; i < s_volley.size(); i++){
-            rand_offset = Math::randf() * scatter_range - scatter_range / 2;
-            Dictionary shot_info = s_volley[i];
-            shot_info["direction"] = Vector2(shot_info["direction"]).rotated(rand_offset);
-        }
-        break;
-    
-    case VOLLEY:
-        rand_offset = Math::randf() * scatter_range - scatter_range / 2;
-        for (int i = 0; i < s_volley.size(); i++){
-            Dictionary shot_info = s_volley[i];
-            shot_info["direction"] = Vector2(shot_info["direction"]).rotated(rand_offset);
-        }
-        break;
-
-    default:
-        break;
+  switch (scatter_mode)
+  {
+  case BULLET:
+    for (int i = 0; i < s_volley.size(); i++){
+      rand_offset = Math::randf() * scatter_range - scatter_range / 2;
+      Dictionary shot_info = s_volley[i];
+      shot_info["direction"] = Vector2(shot_info["direction"]).rotated(rand_offset);
     }
-    return s_volley;
+    break;
+
+  case VOLLEY:
+    rand_offset = Math::randf() * scatter_range - scatter_range / 2;
+    for (int i = 0; i < s_volley.size(); i++){
+      Dictionary shot_info = s_volley[i];
+      shot_info["direction"] = Vector2(shot_info["direction"]).rotated(rand_offset);
+    }
+    break;
+
+  default:
+    break;
+  }
+  return s_volley;
 }
 
 //private functions
 Array BulletSpawner::_get_selected_shots(const Array &p_volley, const PoolIntArray &p_shot_indices) const {
-    Array selected_shots;
-    Dictionary used_indices;
-    for (int i = 0; i < p_shot_indices.size(); i++){
-        int shot_index = p_shot_indices[i];
-        if (shot_index > -1 && shot_index < p_volley.size() && !used_indices.has(shot_index)){
-            selected_shots.append(p_volley[shot_index]);
-            used_indices[shot_index] = true;
-        }
+  Array selected_shots;
+  Dictionary used_indices;
+  for (int i = 0; i < p_shot_indices.size(); i++){
+    int shot_index = p_shot_indices[i];
+    if (shot_index > -1 && shot_index < p_volley.size() && !used_indices.has(shot_index)){
+      selected_shots.append(p_volley[shot_index]);
+      used_indices[shot_index] = true;
     }
-    return selected_shots;
+  }
+  return selected_shots;
 }
 
 void BulletSpawner::_volley_change_notify() {
-    _volley_changed = true;
+  _volley_changed = true;
 #ifdef TOOLS_ENABLED
-	update_configuration_warning();
+  update_configuration_warning();
 #endif
-    if(is_visible_in_tree()){
-        update();
-    }
+  if(is_visible_in_tree()){
+    update();
+  }
 }
 
 Array BulletSpawner::_create_volley() const {
-    Array volley;
-    if (_get_unique_shot_count(true) == 1){
-        Vector2 dir = Vector2(1,0).rotated(arc_rotation);
-        Dictionary shot;
-        shot["normal"] = dir;
-        shot["position"] = _get_shot_position(dir);
-        shot["direction"] = _get_shot_direction(dir * radius, dir);
-        volley.push_back(shot);
-        return volley;
-    }
-
-    float arc_extent = arc_width / 2;
-    float spacing = arc_width / (shot_count - 1);
-    bool spacing_maxed = false;
-
-    float volley_start = -arc_extent;
-    if (spacing > 2 * Math_PI / shot_count){
-        spacing = 2 * Math_PI / shot_count;
-        volley_start = -Math_PI + spacing / 2;
-        spacing_maxed = true;
-    }
-
-    for (int i = 0; i < shot_count; i++){
-        float shot_angle = spacing * i + (arc_offset * arc_width / 2);
-        if (!spacing_maxed){
-            shot_angle = Math::wrapf(shot_angle, 0 - spacing / 2, arc_width + spacing / 2);
-        }
-        shot_angle += volley_start;
-        Vector2 shot_normal = Vector2(1,0).rotated(shot_angle);
-        if (arc_width >= 2 * Math_PI || Math::abs(shot_normal.angle()) <= arc_extent + 0.001){
-            Dictionary shot;
-            shot_normal = shot_normal.rotated(arc_rotation);
-            shot["normal"] = shot_normal;
-            shot["position"] = _get_shot_position(shot_normal);
-            shot["direction"] = _get_shot_direction(shot["position"], shot_normal);
-            volley.push_back(shot);
-        }
-    }
+  Array volley;
+  if (_get_unique_shot_count(true) == 1){
+    Vector2 dir = Vector2(1,0).rotated(arc_rotation);
+    Dictionary shot;
+    shot["normal"] = dir;
+    shot["position"] = _get_shot_position(dir);
+    shot["direction"] = _get_shot_direction(dir * radius, dir);
+    volley.push_back(shot);
     return volley;
+  }
+
+  float arc_extent = arc_width / 2;
+  float spacing = arc_width / (shot_count - 1);
+  bool spacing_maxed = false;
+
+  float volley_start = -arc_extent;
+  if (spacing > 2 * Math_PI / shot_count){
+    spacing = 2 * Math_PI / shot_count;
+    volley_start = -Math_PI + spacing / 2;
+    spacing_maxed = true;
+  }
+
+  for (int i = 0; i < shot_count; i++){
+    float shot_angle = spacing * i + (arc_offset * arc_width / 2);
+    if (!spacing_maxed){
+      shot_angle = Math::wrapf(shot_angle, 0 - spacing / 2, arc_width + spacing / 2);
+    }
+    shot_angle += volley_start;
+    Vector2 shot_normal = Vector2(1,0).rotated(shot_angle);
+    if (arc_width >= 2 * Math_PI || Math::abs(shot_normal.angle()) <= arc_extent + 0.001){
+      Dictionary shot;
+      shot_normal = shot_normal.rotated(arc_rotation);
+      shot["normal"] = shot_normal;
+      shot["position"] = _get_shot_position(shot_normal);
+      shot["direction"] = _get_shot_direction(shot["position"], shot_normal);
+      volley.push_back(shot);
+    }
+  }
+  return volley;
 }
 
 Vector2 BulletSpawner::_get_shot_position(const Vector2 &p_normal) const{
-    return (p_normal * radius * get_global_scale()).rotated(get_global_rotation());
+  return (p_normal * radius * get_global_scale()).rotated(get_global_rotation());
 }
 
 Vector2 BulletSpawner::_get_shot_direction(const Vector2 &p_position, const Vector2 &p_normal) const{
-    Vector2 direction;
-    switch (aim_mode){
-        case RADIAL: {
-            direction = p_normal.rotated(aim_angle + get_global_rotation());
-        } break;
-        case UNIFORM: {
-            direction = Vector2(1,0).rotated(aim_angle + get_global_rotation());
-        } break;
-        case TARGET_RELATIVE: {
-            direction = (aim_target_position - p_position).normalized();
-        } break;
-        case TARGET_GLOBAL: {
-            direction = (aim_target_position - (get_global_position() + p_position)).normalized();
-        } break;
-        default:{
-        } break;
-    }
-    //if calculated direction is not a normal, such as when targeted aim modes aim at their own current position, use the initial shot normal instead
-    if (!direction.is_normalized()){
-        direction = p_normal;
-    }
-    return direction;
+  Vector2 direction;
+  switch (aim_mode){
+    case RADIAL: {
+      direction = p_normal.rotated(aim_angle + get_global_rotation());
+    } break;
+    case UNIFORM: {
+      direction = Vector2(1,0).rotated(aim_angle + get_global_rotation());
+    } break;
+    case TARGET_RELATIVE: {
+      direction = (aim_target_position - p_position).normalized();
+    } break;
+    case TARGET_GLOBAL: {
+      direction = (aim_target_position - (get_global_position() + p_position)).normalized();
+    } break;
+    default:{
+    } break;
+  }
+  //if calculated direction is not a normal, such as when targeted aim modes aim at their own current position, use the initial shot normal instead
+  if (!direction.is_normalized()){
+    direction = p_normal;
+  }
+  return direction;
 }
 
 int BulletSpawner::_get_unique_shot_count(bool p_include_scatter) const {
-    //returns number of shots that will follow a unique path (or have potential to, with scatter) after firing
-    //used in checks to prevent an entire volley from "stacking" by being spawned in the same position with the same direction
-    if (shot_count <= 1){
-        return 1;
+  //returns number of shots that will follow a unique path (or have potential to, with scatter) after firing
+  //used in checks to prevent an entire volley from "stacking" by being spawned in the same position with the same direction
+  if (shot_count <= 1){
+    return 1;
+  }
+  if (Math::is_zero_approx(arc_width) || (aim_mode != RADIAL && Math::is_zero_approx(radius))) {
+    if (p_include_scatter && scatter_mode == BULLET && !Math::is_zero_approx(scatter_range)){
+      return shot_count;
     }
-    if (Math::is_zero_approx(arc_width) || (aim_mode != RADIAL && Math::is_zero_approx(radius))) {
-        if (p_include_scatter && scatter_mode == BULLET && !Math::is_zero_approx(scatter_range)){
-            return shot_count;
-        }
-        return 1;
-    }
-    return shot_count;
+    return 1;
+  }
+  return shot_count;
 }
 
 //setters/getters
 void BulletSpawner::set_autofire(bool p_enabled) {
-    autofire = p_enabled;
-    if (autofire){
-        _autofire_time = INFINITY;
-    } else {
-        _autofire_time = 0;
-    }
+  autofire = p_enabled;
+  if (autofire){
+    _autofire_time = INFINITY;
+  } else {
+    _autofire_time = 0;
+  }
 }
 
 bool BulletSpawner::get_autofire() const {
-    return autofire;
+  return autofire;
 }
 
 void BulletSpawner::set_interval_frames(int p_interval) {
-    interval_frames = p_interval;
+  interval_frames = p_interval;
 }
 
 int BulletSpawner::get_interval_frames() const {
-    return interval_frames;
+  return interval_frames;
 }
 
 void BulletSpawner::set_bullet_type(const Ref<BulletType> &p_type) {
-    bullet_type = p_type;
-    _volley_change_notify();
+  bullet_type = p_type;
+  _volley_change_notify();
 }
 
 Ref<BulletType> BulletSpawner::get_bullet_type() const {
-    return bullet_type;
+  return bullet_type;
 }
 
 void BulletSpawner::set_shot_count(int p_count) {
-    shot_count = p_count;
-    _volley_change_notify();
+  shot_count = p_count;
+  _volley_change_notify();
 }
 
 int BulletSpawner::get_shot_count() const {
-    return shot_count;
+  return shot_count;
 }
 
 void BulletSpawner::set_radius(float p_radius) {
-    radius = p_radius;
-    _volley_change_notify();    
+  radius = p_radius;
+  _volley_change_notify();
 }
 
 float BulletSpawner::get_radius() const {
-    return radius;
+  return radius;
 }
 
 void BulletSpawner::set_arc_width(float p_radians){
-    arc_width = p_radians;
-    _volley_change_notify();
+  arc_width = p_radians;
+  _volley_change_notify();
 }
 
 float BulletSpawner::get_arc_width() const {
-    return arc_width;
+  return arc_width;
 }
 
 void BulletSpawner::set_arc_width_degrees(float p_degrees){
-    arc_width = Math::deg2rad(p_degrees);
-    _volley_change_notify();
+  arc_width = Math::deg2rad(p_degrees);
+  _volley_change_notify();
 }
 
 float BulletSpawner::get_arc_width_degrees() const {
-    return Math::rad2deg(arc_width);
+  return Math::rad2deg(arc_width);
 }
 
 void BulletSpawner::set_arc_rotation(float p_radians) {
-    arc_rotation = p_radians;
-    _volley_change_notify();
+  arc_rotation = p_radians;
+  _volley_change_notify();
 }
 
 float BulletSpawner::get_arc_rotation() const {
-    return arc_rotation;
+  return arc_rotation;
 }
 
 void BulletSpawner::set_arc_rotation_degrees(float p_degrees) {
-    arc_rotation = Math::deg2rad(p_degrees);
-    _volley_change_notify();
+  arc_rotation = Math::deg2rad(p_degrees);
+  _volley_change_notify();
 }
 
 float BulletSpawner::get_arc_rotation_degrees() const {
-    return Math::rad2deg(arc_rotation);
+  return Math::rad2deg(arc_rotation);
 }
 
 void BulletSpawner::set_arc_offset(float p_offset) {
-    arc_offset = p_offset;
-    _volley_change_notify();
+  arc_offset = p_offset;
+  _volley_change_notify();
 }
 
 float BulletSpawner::get_arc_offset() const {
-    return arc_offset;
+  return arc_offset;
 }
 
 void BulletSpawner::set_aim_mode(AimMode p_mode){
-    aim_mode = p_mode;
-    _volley_change_notify();
-    _change_notify();
+  aim_mode = p_mode;
+  _volley_change_notify();
+  _change_notify();
 }
 
 BulletSpawner::AimMode BulletSpawner::get_aim_mode() const {
-    return aim_mode;
+  return aim_mode;
 }
 
 
 void BulletSpawner::set_aim_angle(float p_radians){
-    aim_angle = p_radians;
-    if (aim_mode == RADIAL || aim_mode == UNIFORM){
-        _volley_change_notify();
-    }
+  aim_angle = p_radians;
+  if (aim_mode == RADIAL || aim_mode == UNIFORM){
+    _volley_change_notify();
+  }
 }
 
 float BulletSpawner::get_aim_angle() const {
-    return aim_angle;
+  return aim_angle;
 }
 
 void BulletSpawner::set_aim_angle_degrees(float p_degrees) {
-    set_aim_angle(Math::deg2rad(p_degrees));
+  set_aim_angle(Math::deg2rad(p_degrees));
 }
 
 float BulletSpawner::get_aim_angle_degrees() const {
-    return Math::rad2deg(aim_angle);
+  return Math::rad2deg(aim_angle);
 }
 
 void BulletSpawner::set_aim_target_position(const Vector2 &p_position) {
-    aim_target_position = p_position;
-    if (aim_mode == TARGET_RELATIVE || aim_mode == TARGET_GLOBAL) {
-        _volley_change_notify();
-    }
+  aim_target_position = p_position;
+  if (aim_mode == TARGET_RELATIVE || aim_mode == TARGET_GLOBAL) {
+    _volley_change_notify();
+  }
 }
 
 Vector2 BulletSpawner::get_aim_target_position() const {
-    return aim_target_position;
+  return aim_target_position;
 }
 
 void BulletSpawner::set_scatter_mode(ScatterMode p_mode) {
-    scatter_mode = p_mode;
-    _change_notify();
+  scatter_mode = p_mode;
+  _change_notify();
 }
 
 BulletSpawner::ScatterMode BulletSpawner::get_scatter_mode() const {
-    return scatter_mode;
+  return scatter_mode;
 }
 
 void BulletSpawner::set_scatter_range(float p_radians) {
-    scatter_range = p_radians;
+  scatter_range = p_radians;
 }
 
 float BulletSpawner::get_scatter_range() const {
-    return scatter_range;
+  return scatter_range;
 }
 
 void BulletSpawner::set_scatter_range_degrees(float p_degrees) {
-    scatter_range = Math::deg2rad(p_degrees);
+  scatter_range = Math::deg2rad(p_degrees);
 }
 
 float BulletSpawner::get_scatter_range_degrees() const {
-    return Math::rad2deg(scatter_range);
+  return Math::rad2deg(scatter_range);
 }
 
 void BulletSpawner::set_pattern_mode(PatternMode p_mode) {
-    pattern_mode = p_mode;
-    _volley_change_notify();
-    _change_notify();
+  pattern_mode = p_mode;
+  _volley_change_notify();
+  _change_notify();
 }
 
 BulletSpawner::PatternMode BulletSpawner::get_pattern_mode() const {
-    return pattern_mode;
+  return pattern_mode;
 }
 
 void BulletSpawner::set_active_shot_indices(const PoolIntArray &p_points) {
-    active_shot_indices = p_points;
-    _volley_change_notify();
+  active_shot_indices = p_points;
+  _volley_change_notify();
 }
 
 PoolIntArray BulletSpawner::get_active_shot_indices() const{
-    return active_shot_indices;
+  return active_shot_indices;
 }
 
 void BulletSpawner::set_preview_visible_in_game(bool p_enabled){
-    preview_visible_in_game = p_enabled;
-    if (is_visible_in_tree()){
-        update();
-    }
+  preview_visible_in_game = p_enabled;
+  if (is_visible_in_tree()){
+    update();
+  }
 }
 
 bool BulletSpawner::get_preview_visible_in_game() const {
-    return preview_visible_in_game;
+  return preview_visible_in_game;
 }
 
 void BulletSpawner::set_preview_color(const Color &p_color){
-    preview_color = p_color;
-    if (is_visible_in_tree()) {
-        update();
-    }
+  preview_color = p_color;
+  if (is_visible_in_tree()) {
+    update();
+  }
 }
 
 Color BulletSpawner::get_preview_color() const {
-    return preview_color;
+  return preview_color;
 }
 
 void BulletSpawner::set_preview_shot_color(const Color &p_color){
-    preview_shot_color = p_color;
-    if (is_visible_in_tree()) {
-        update();
-    }
+  preview_shot_color = p_color;
+  if (is_visible_in_tree()) {
+    update();
+  }
 }
 
 Color BulletSpawner::get_preview_shot_color() const {
-    return preview_shot_color;
+  return preview_shot_color;
 }
 
 void BulletSpawner::set_preview_extent(float p_length){
-    preview_extent = p_length;
-    if (is_visible_in_tree()) {
-        update();
-    }
+  preview_extent = p_length;
+  if (is_visible_in_tree()) {
+    update();
+  }
 }
 
 float BulletSpawner::get_preview_extent() const {
-    return preview_extent;
+  return preview_extent;
 }
 
 void BulletSpawner::set_preview_arc_points(int p_count){
-    preview_arc_points = p_count;
-    if (is_visible_in_tree()) {
-        update();
-    }
+  preview_arc_points = p_count;
+  if (is_visible_in_tree()) {
+    update();
+  }
 }
 
 int BulletSpawner::get_preview_arc_points() const {
-    return preview_arc_points;
+  return preview_arc_points;
 }
 
 void BulletSpawner::set_relay_autoconnect(bool p_enabled) {
-	relay_autoconnect = p_enabled;
+  relay_autoconnect = p_enabled;
 }
 
 bool BulletSpawner::get_relay_autoconnect() const {
-	return relay_autoconnect;
+  return relay_autoconnect;
 }
 
 //drawing functions
-void BulletSpawner::_draw_preview(const Color &p_border_col, const Color &p_shot_col) { 
-    Color dim_border_col = Color(p_border_col.r, p_border_col.g, p_border_col.b, 0.25);
-    Color dim_shot_col = Color(p_shot_col.r, p_shot_col.g, p_shot_col.b, 0.25);
+void BulletSpawner::_draw_preview(const Color &p_border_col, const Color &p_shot_col) {
+  Color dim_border_col = Color(p_border_col.r, p_border_col.g, p_border_col.b, 0.25);
+  Color dim_shot_col = Color(p_shot_col.r, p_shot_col.g, p_shot_col.b, 0.25);
 
-    if (_get_unique_shot_count() > 1) {
-        Vector<Vector2> inner_points;
-        Vector<Vector2> outer_points;
-        inner_points.resize(preview_arc_points);
-        outer_points.resize(preview_arc_points);
-        float arc_extent = arc_width / 2;
-        for (int i = 0; i < inner_points.size(); i++) {
-            Vector2 normal = Vector2(cos(-arc_extent), sin(-arc_extent)).rotated(arc_width / (inner_points.size() - 1) * i + arc_rotation);
-            Vector2 inner_point = normal * radius;
-            Vector2 outer_point = _get_outer_preview_point(inner_point, normal, preview_extent);
-            inner_points.set(i, inner_point);
-            outer_points.set(i, outer_point);
-        }
-        if (arc_width < 2* Math_PI){
-            outer_points.insert(0, inner_points[0]);
-            outer_points.push_back(inner_points[inner_points.size() - 1]);
-            draw_polyline(inner_points, p_border_col);
-            draw_polyline(outer_points, dim_border_col);
-        } else {
-            draw_polyline(inner_points, p_border_col);
-            draw_polyline(outer_points, dim_border_col);
-        }
+  if (_get_unique_shot_count() > 1) {
+    Vector<Vector2> inner_points;
+    Vector<Vector2> outer_points;
+    inner_points.resize(preview_arc_points);
+    outer_points.resize(preview_arc_points);
+    float arc_extent = arc_width / 2;
+    for (int i = 0; i < inner_points.size(); i++) {
+      Vector2 normal = Vector2(cos(-arc_extent), sin(-arc_extent)).rotated(arc_width / (inner_points.size() - 1) * i + arc_rotation);
+      Vector2 inner_point = normal * radius;
+      Vector2 outer_point = _get_outer_preview_point(inner_point, normal, preview_extent);
+      inner_points.set(i, inner_point);
+      outer_points.set(i, outer_point);
     }
-
-
-    Vector2 crosshair_normal = Vector2(1,0).rotated(arc_rotation);
-    Vector2 crosshair_inner_point = crosshair_normal * radius;
-    Vector2 crosshair_outer_point = _get_outer_preview_point(crosshair_inner_point, crosshair_normal, preview_extent);
-    draw_line(Vector2(), crosshair_inner_point, p_border_col);
-    draw_line(crosshair_outer_point, _get_outer_preview_point(crosshair_inner_point, crosshair_normal, preview_extent + preview_extent / 5), p_border_col);
-    draw_line(crosshair_inner_point, crosshair_outer_point, dim_border_col);
-    
-    if (_get_unique_shot_count() > 1){
-        _draw_shot_lines(get_volley(), preview_extent, dim_shot_col);
-        if (pattern_mode == MANUAL) {
-            _draw_shot_lines(_get_selected_shots(get_volley(), active_shot_indices), preview_extent / 5, p_shot_col);
-        } else {
-            _draw_shot_lines(get_volley(), preview_extent / 5, p_shot_col);
-        }
+    if (arc_width < 2* Math_PI){
+      outer_points.insert(0, inner_points[0]);
+      outer_points.push_back(inner_points[inner_points.size() - 1]);
+      draw_polyline(inner_points, p_border_col);
+      draw_polyline(outer_points, dim_border_col);
     } else {
-        draw_line(crosshair_inner_point, crosshair_outer_point, dim_shot_col);
-        draw_line(crosshair_inner_point, crosshair_inner_point + (crosshair_outer_point - crosshair_inner_point) / 5, p_shot_col);
+      draw_polyline(inner_points, p_border_col);
+      draw_polyline(outer_points, dim_border_col);
     }
+  }
 
-    if (aim_mode == TARGET_RELATIVE) {
-        draw_circle(aim_target_position.rotated(-get_global_rotation()) / get_global_scale(), 1, p_border_col);
-    } else if (aim_mode == TARGET_GLOBAL) {
-        draw_circle((aim_target_position - get_global_position()).rotated(-get_global_rotation()) / get_global_scale(), 1, p_border_col);
+
+  Vector2 crosshair_normal = Vector2(1,0).rotated(arc_rotation);
+  Vector2 crosshair_inner_point = crosshair_normal * radius;
+  Vector2 crosshair_outer_point = _get_outer_preview_point(crosshair_inner_point, crosshair_normal, preview_extent);
+  draw_line(Vector2(), crosshair_inner_point, p_border_col);
+  draw_line(crosshair_outer_point, _get_outer_preview_point(crosshair_inner_point, crosshair_normal, preview_extent + preview_extent / 5), p_border_col);
+  draw_line(crosshair_inner_point, crosshair_outer_point, dim_border_col);
+
+  if (_get_unique_shot_count() > 1){
+    _draw_shot_lines(get_volley(), preview_extent, dim_shot_col);
+    if (pattern_mode == MANUAL) {
+      _draw_shot_lines(_get_selected_shots(get_volley(), active_shot_indices), preview_extent / 5, p_shot_col);
+    } else {
+      _draw_shot_lines(get_volley(), preview_extent / 5, p_shot_col);
     }
+  } else {
+    draw_line(crosshair_inner_point, crosshair_outer_point, dim_shot_col);
+    draw_line(crosshair_inner_point, crosshair_inner_point + (crosshair_outer_point - crosshair_inner_point) / 5, p_shot_col);
+  }
+
+  if (aim_mode == TARGET_RELATIVE) {
+    draw_circle(aim_target_position.rotated(-get_global_rotation()) / get_global_scale(), 1, p_border_col);
+  } else if (aim_mode == TARGET_GLOBAL) {
+    draw_circle((aim_target_position - get_global_position()).rotated(-get_global_rotation()) / get_global_scale(), 1, p_border_col);
+  }
 }
 
 Vector2 BulletSpawner::_get_outer_preview_point(const Vector2 &p_inner_point, const Vector2 &p_inner_normal, float p_extent) const {
-    Vector2 outer_point;
-    switch (aim_mode) {
-        case RADIAL: {
-            outer_point = p_inner_point + p_inner_normal.rotated(aim_angle) * p_extent / get_global_scale();
-        } break;
+  Vector2 outer_point;
+  switch (aim_mode) {
+    case RADIAL: {
+      outer_point = p_inner_point + p_inner_normal.rotated(aim_angle) * p_extent / get_global_scale();
+    } break;
 
-        case UNIFORM: {
-            outer_point = p_inner_point + Vector2(1,0).rotated(aim_angle) * p_extent / get_global_scale();
-        } break;
+    case UNIFORM: {
+      outer_point = p_inner_point + Vector2(1,0).rotated(aim_angle) * p_extent / get_global_scale();
+    } break;
 
-        case TARGET_RELATIVE: {
-            Vector2 transformed_inner = p_inner_point * get_global_scale();
-            Vector2 local_target = aim_target_position.rotated(-get_global_rotation());
-            if (transformed_inner.distance_to(local_target) < p_extent){
-                outer_point = local_target / get_global_scale();
-            } else {
-                outer_point = p_inner_point + (local_target - transformed_inner).normalized() * p_extent / get_global_scale();
-            }
-        } break;
-        
-        case TARGET_GLOBAL: {
-            Vector2 global_inner_point = get_global_position() + (p_inner_point * get_global_scale()).rotated(get_global_rotation());
-            Vector2 local_target = (aim_target_position - get_global_position()).rotated(-get_global_rotation()) / get_global_scale();
-            if (global_inner_point.distance_to(aim_target_position) < p_extent){
-                outer_point = local_target;
-            } else {
-                outer_point = p_inner_point + (aim_target_position - global_inner_point).rotated(-get_global_rotation()).normalized() * p_extent / get_global_scale();
-            }
-        } break;
-        
-        default:
-            break;
-    }
-    return outer_point;
+    case TARGET_RELATIVE: {
+      Vector2 transformed_inner = p_inner_point * get_global_scale();
+      Vector2 local_target = aim_target_position.rotated(-get_global_rotation());
+      if (transformed_inner.distance_to(local_target) < p_extent){
+        outer_point = local_target / get_global_scale();
+      } else {
+        outer_point = p_inner_point + (local_target - transformed_inner).normalized() * p_extent / get_global_scale();
+      }
+    } break;
+
+    case TARGET_GLOBAL: {
+      Vector2 global_inner_point = get_global_position() + (p_inner_point * get_global_scale()).rotated(get_global_rotation());
+      Vector2 local_target = (aim_target_position - get_global_position()).rotated(-get_global_rotation()) / get_global_scale();
+      if (global_inner_point.distance_to(aim_target_position) < p_extent){
+        outer_point = local_target;
+      } else {
+        outer_point = p_inner_point + (aim_target_position - global_inner_point).rotated(-get_global_rotation()).normalized() * p_extent / get_global_scale();
+      }
+    } break;
+
+    default:
+      break;
+  }
+  return outer_point;
 }
 
 void BulletSpawner::_draw_shot_lines(const Array &p_volley, float p_length, const Color &p_color) {
-    for (int i = 0; i < p_volley.size(); i++){
-        Dictionary shot = p_volley[i];
-        Vector2 normal = shot["normal"];
-        Vector2 position = shot["position"];
-        Vector2 local_position = position.rotated(-get_global_rotation()) / get_global_scale();
-        draw_line(local_position, _get_outer_preview_point(local_position, normal, p_length), p_color);
-    }
+  for (int i = 0; i < p_volley.size(); i++){
+    Dictionary shot = p_volley[i];
+    Vector2 normal = shot["normal"];
+    Vector2 position = shot["position"];
+    Vector2 local_position = position.rotated(-get_global_rotation()) / get_global_scale();
+    draw_line(local_position, _get_outer_preview_point(local_position, normal, p_length), p_color);
+  }
 }
 
 void BulletSpawner::_validate_property(PropertyInfo &property) const{
-    if (property.name == "scatter_range_degrees" && scatter_mode == NONE){
-        property.usage = 0;
-    }
+  if (property.name == "scatter_range_degrees" && scatter_mode == NONE){
+    property.usage = 0;
+  }
 
-    if (property.name == "aim_target_position" && !(aim_mode == TARGET_RELATIVE || aim_mode == TARGET_GLOBAL)){
-        property.usage = PROPERTY_USAGE_NOEDITOR;
-    }
+  if (property.name == "aim_target_position" && !(aim_mode == TARGET_RELATIVE || aim_mode == TARGET_GLOBAL)){
+    property.usage = PROPERTY_USAGE_NOEDITOR;
+  }
 
-    if (property.name == "aim_angle_degrees" && !(aim_mode == RADIAL || aim_mode == UNIFORM)){
-        property.usage = PROPERTY_USAGE_NOEDITOR;
-    }
+  if (property.name == "aim_angle_degrees" && !(aim_mode == RADIAL || aim_mode == UNIFORM)){
+    property.usage = PROPERTY_USAGE_NOEDITOR;
+  }
 
-    if (property.name == "active_shot_indices" && pattern_mode != MANUAL){
-        property.usage = PROPERTY_USAGE_NOEDITOR;
-    }
+  if (property.name == "active_shot_indices" && pattern_mode != MANUAL){
+    property.usage = PROPERTY_USAGE_NOEDITOR;
+  }
 }
 
 String BulletSpawner::get_configuration_warning() const {
-    String warning;
-    if (bullet_type.is_null()){
-        warning += TTR("This BulletSpawner has no BulletType configured, and will not be able to fire bullets.\nConsider defining one in the BulletSpawner's properties.");
-    }
-    
-    if (pattern_mode == MANUAL && !Math::is_zero_approx(arc_offset)){
-        if (warning != String()){
-            warning += "\n\n";
-        }
-        warning += TTR("This BulletSpawner has a non-zero arc_offset while in MANUAL pattern mode. Shot indices may shift unexpectedly.\nConsider setting the pattern mode to ALL or the arc_offset to zero, depending on your needs.");
-    }
+  String warning;
+  if (bullet_type.is_null()){
+    warning += TTR("This BulletSpawner has no BulletType configured, and will not be able to fire bullets.\nConsider defining one in the BulletSpawner's properties.");
+  }
 
-    if (aim_mode != RADIAL && Math::is_zero_approx(radius)){
-        if (warning != String()){
-            warning += "\n\n";
-        }
-        warning += TTR("This BulletSpawner has a radius of zero, and aim_mode is not RADIAL.\nWith this configuration, only one bullet will be fired, regardless of bullet count and arc width, because all bullets would have identical flight paths.");
+  if (pattern_mode == MANUAL && !Math::is_zero_approx(arc_offset)){
+    if (warning != String()){
+      warning += "\n\n";
     }
+    warning += TTR("This BulletSpawner has a non-zero arc_offset while in MANUAL pattern mode. Shot indices may shift unexpectedly.\nConsider setting the pattern mode to ALL or the arc_offset to zero, depending on your needs.");
+  }
 
-    return warning;
+  if (aim_mode != RADIAL && Math::is_zero_approx(radius)){
+    if (warning != String()){
+      warning += "\n\n";
+    }
+    warning += TTR("This BulletSpawner has a radius of zero, and aim_mode is not RADIAL.\nWith this configuration, only one bullet will be fired, regardless of bullet count and arc width, because all bullets would have identical flight paths.");
+  }
+
+  return warning;
 }
 
 //godot binds
 void BulletSpawner::_bind_methods() {
-    ClassDB::bind_method(D_METHOD("can_fire"), &BulletSpawner::can_fire);
-    ClassDB::bind_method(D_METHOD("fire"), &BulletSpawner::fire);
-    ClassDB::bind_method(D_METHOD("fire_shots", "shot_indices"), &BulletSpawner::fire_shots);
+  ClassDB::bind_method(D_METHOD("can_fire"), &BulletSpawner::can_fire);
+  ClassDB::bind_method(D_METHOD("fire"), &BulletSpawner::fire);
+  ClassDB::bind_method(D_METHOD("fire_shots", "shot_indices"), &BulletSpawner::fire_shots);
 
-    ClassDB::bind_method(D_METHOD("get_volley"), &BulletSpawner::get_volley);
-    ClassDB::bind_method(D_METHOD("get_scattered_volley"), &BulletSpawner::get_scattered_volley);
+  ClassDB::bind_method(D_METHOD("get_volley"), &BulletSpawner::get_volley);
+  ClassDB::bind_method(D_METHOD("get_scattered_volley"), &BulletSpawner::get_scattered_volley);
 
-    ClassDB::bind_method(D_METHOD("set_autofire", "enabled"), &BulletSpawner::set_autofire);
-    ClassDB::bind_method(D_METHOD("get_autofire"), &BulletSpawner::get_autofire);
+  ClassDB::bind_method(D_METHOD("set_autofire", "enabled"), &BulletSpawner::set_autofire);
+  ClassDB::bind_method(D_METHOD("get_autofire"), &BulletSpawner::get_autofire);
 
-    ClassDB::bind_method(D_METHOD("set_interval_frames", "interval"), &BulletSpawner::set_interval_frames);
-    ClassDB::bind_method(D_METHOD("get_interval_frames"), &BulletSpawner::get_interval_frames);
+  ClassDB::bind_method(D_METHOD("set_interval_frames", "interval"), &BulletSpawner::set_interval_frames);
+  ClassDB::bind_method(D_METHOD("get_interval_frames"), &BulletSpawner::get_interval_frames);
 
-    ClassDB::bind_method(D_METHOD("set_shot_count", "count"), &BulletSpawner::set_shot_count);
-    ClassDB::bind_method(D_METHOD("get_shot_count"), &BulletSpawner::get_shot_count);
+  ClassDB::bind_method(D_METHOD("set_shot_count", "count"), &BulletSpawner::set_shot_count);
+  ClassDB::bind_method(D_METHOD("get_shot_count"), &BulletSpawner::get_shot_count);
 
-    ClassDB::bind_method(D_METHOD("set_radius", "radius"), &BulletSpawner::set_radius);
-    ClassDB::bind_method(D_METHOD("get_radius"), &BulletSpawner::get_radius);
+  ClassDB::bind_method(D_METHOD("set_radius", "radius"), &BulletSpawner::set_radius);
+  ClassDB::bind_method(D_METHOD("get_radius"), &BulletSpawner::get_radius);
 
-    ClassDB::bind_method(D_METHOD("set_arc_width", "radians"), &BulletSpawner::set_arc_width);
-    ClassDB::bind_method(D_METHOD("get_arc_width"), &BulletSpawner::get_arc_width);
+  ClassDB::bind_method(D_METHOD("set_arc_width", "radians"), &BulletSpawner::set_arc_width);
+  ClassDB::bind_method(D_METHOD("get_arc_width"), &BulletSpawner::get_arc_width);
 
-    ClassDB::bind_method(D_METHOD("set_arc_width_degrees", "degrees"), &BulletSpawner::set_arc_width_degrees);
-    ClassDB::bind_method(D_METHOD("get_arc_width_degrees"), &BulletSpawner::get_arc_width_degrees);
+  ClassDB::bind_method(D_METHOD("set_arc_width_degrees", "degrees"), &BulletSpawner::set_arc_width_degrees);
+  ClassDB::bind_method(D_METHOD("get_arc_width_degrees"), &BulletSpawner::get_arc_width_degrees);
 
-    ClassDB::bind_method(D_METHOD("set_arc_rotation", "radians"), &BulletSpawner::set_arc_rotation);
-    ClassDB::bind_method(D_METHOD("get_arc_rotation"), &BulletSpawner::get_arc_rotation);
+  ClassDB::bind_method(D_METHOD("set_arc_rotation", "radians"), &BulletSpawner::set_arc_rotation);
+  ClassDB::bind_method(D_METHOD("get_arc_rotation"), &BulletSpawner::get_arc_rotation);
 
-    ClassDB::bind_method(D_METHOD("set_arc_rotation_degrees", "degrees"), &BulletSpawner::set_arc_rotation_degrees);
-    ClassDB::bind_method(D_METHOD("get_arc_rotation_degrees"), &BulletSpawner::get_arc_rotation_degrees);
+  ClassDB::bind_method(D_METHOD("set_arc_rotation_degrees", "degrees"), &BulletSpawner::set_arc_rotation_degrees);
+  ClassDB::bind_method(D_METHOD("get_arc_rotation_degrees"), &BulletSpawner::get_arc_rotation_degrees);
 
-    ClassDB::bind_method(D_METHOD("set_arc_offset", "offset"), &BulletSpawner::set_arc_offset);
-    ClassDB::bind_method(D_METHOD("get_arc_offset"), &BulletSpawner::get_arc_offset);
+  ClassDB::bind_method(D_METHOD("set_arc_offset", "offset"), &BulletSpawner::set_arc_offset);
+  ClassDB::bind_method(D_METHOD("get_arc_offset"), &BulletSpawner::get_arc_offset);
 
-    ClassDB::bind_method(D_METHOD("set_bullet_type", "type"), &BulletSpawner::set_bullet_type);
-    ClassDB::bind_method(D_METHOD("get_bullet_type"), &BulletSpawner::get_bullet_type);
+  ClassDB::bind_method(D_METHOD("set_bullet_type", "type"), &BulletSpawner::set_bullet_type);
+  ClassDB::bind_method(D_METHOD("get_bullet_type"), &BulletSpawner::get_bullet_type);
 
-    ClassDB::bind_method(D_METHOD("set_aim_mode", "mode"), &BulletSpawner::set_aim_mode);
-    ClassDB::bind_method(D_METHOD("get_aim_mode"), &BulletSpawner::get_aim_mode);
+  ClassDB::bind_method(D_METHOD("set_aim_mode", "mode"), &BulletSpawner::set_aim_mode);
+  ClassDB::bind_method(D_METHOD("get_aim_mode"), &BulletSpawner::get_aim_mode);
 
-    ClassDB::bind_method(D_METHOD("set_aim_angle", "radians"), &BulletSpawner::set_aim_angle);
-    ClassDB::bind_method(D_METHOD("get_aim_angle"), &BulletSpawner::get_aim_angle);
+  ClassDB::bind_method(D_METHOD("set_aim_angle", "radians"), &BulletSpawner::set_aim_angle);
+  ClassDB::bind_method(D_METHOD("get_aim_angle"), &BulletSpawner::get_aim_angle);
 
-    ClassDB::bind_method(D_METHOD("set_aim_angle_degrees", "degrees"), &BulletSpawner::set_aim_angle_degrees);
-    ClassDB::bind_method(D_METHOD("get_aim_angle_degrees"), &BulletSpawner::get_aim_angle_degrees);
+  ClassDB::bind_method(D_METHOD("set_aim_angle_degrees", "degrees"), &BulletSpawner::set_aim_angle_degrees);
+  ClassDB::bind_method(D_METHOD("get_aim_angle_degrees"), &BulletSpawner::get_aim_angle_degrees);
 
-    ClassDB::bind_method(D_METHOD("set_aim_target_position", "mode"), &BulletSpawner::set_aim_target_position);
-    ClassDB::bind_method(D_METHOD("get_aim_target_position"), &BulletSpawner::get_aim_target_position);
+  ClassDB::bind_method(D_METHOD("set_aim_target_position", "mode"), &BulletSpawner::set_aim_target_position);
+  ClassDB::bind_method(D_METHOD("get_aim_target_position"), &BulletSpawner::get_aim_target_position);
 
-    ClassDB::bind_method(D_METHOD("set_scatter_mode", "type"), &BulletSpawner::set_scatter_mode);
-    ClassDB::bind_method(D_METHOD("get_scatter_mode"), &BulletSpawner::get_scatter_mode);
+  ClassDB::bind_method(D_METHOD("set_scatter_mode", "type"), &BulletSpawner::set_scatter_mode);
+  ClassDB::bind_method(D_METHOD("get_scatter_mode"), &BulletSpawner::get_scatter_mode);
 
-    ClassDB::bind_method(D_METHOD("set_scatter_range", "radians"), &BulletSpawner::set_scatter_range);
-    ClassDB::bind_method(D_METHOD("get_scatter_range"), &BulletSpawner::get_scatter_range);
+  ClassDB::bind_method(D_METHOD("set_scatter_range", "radians"), &BulletSpawner::set_scatter_range);
+  ClassDB::bind_method(D_METHOD("get_scatter_range"), &BulletSpawner::get_scatter_range);
 
-    ClassDB::bind_method(D_METHOD("set_scatter_range_degrees", "degrees"), &BulletSpawner::set_scatter_range_degrees);
-    ClassDB::bind_method(D_METHOD("get_scatter_range_degrees"), &BulletSpawner::get_scatter_range_degrees);
+  ClassDB::bind_method(D_METHOD("set_scatter_range_degrees", "degrees"), &BulletSpawner::set_scatter_range_degrees);
+  ClassDB::bind_method(D_METHOD("get_scatter_range_degrees"), &BulletSpawner::get_scatter_range_degrees);
 
-    ClassDB::bind_method(D_METHOD("set_pattern_mode", "mode"), &BulletSpawner::set_pattern_mode);
-    ClassDB::bind_method(D_METHOD("get_pattern_mode"), &BulletSpawner::get_pattern_mode);
+  ClassDB::bind_method(D_METHOD("set_pattern_mode", "mode"), &BulletSpawner::set_pattern_mode);
+  ClassDB::bind_method(D_METHOD("get_pattern_mode"), &BulletSpawner::get_pattern_mode);
 
-    ClassDB::bind_method(D_METHOD("set_active_shot_indices", "mode"), &BulletSpawner::set_active_shot_indices);
-    ClassDB::bind_method(D_METHOD("get_active_shot_indices"), &BulletSpawner::get_active_shot_indices);
+  ClassDB::bind_method(D_METHOD("set_active_shot_indices", "mode"), &BulletSpawner::set_active_shot_indices);
+  ClassDB::bind_method(D_METHOD("get_active_shot_indices"), &BulletSpawner::get_active_shot_indices);
 
-    ClassDB::bind_method(D_METHOD("set_preview_visible_in_game", "mode"), &BulletSpawner::set_preview_visible_in_game);
-    ClassDB::bind_method(D_METHOD("get_preview_visible_in_game"), &BulletSpawner::get_preview_visible_in_game);
+  ClassDB::bind_method(D_METHOD("set_preview_visible_in_game", "mode"), &BulletSpawner::set_preview_visible_in_game);
+  ClassDB::bind_method(D_METHOD("get_preview_visible_in_game"), &BulletSpawner::get_preview_visible_in_game);
 
-    ClassDB::bind_method(D_METHOD("set_preview_color", "mode"), &BulletSpawner::set_preview_color);
-    ClassDB::bind_method(D_METHOD("get_preview_color"), &BulletSpawner::get_preview_color);
+  ClassDB::bind_method(D_METHOD("set_preview_color", "mode"), &BulletSpawner::set_preview_color);
+  ClassDB::bind_method(D_METHOD("get_preview_color"), &BulletSpawner::get_preview_color);
 
-    ClassDB::bind_method(D_METHOD("set_preview_shot_color", "mode"), &BulletSpawner::set_preview_shot_color);
-    ClassDB::bind_method(D_METHOD("get_preview_shot_color"), &BulletSpawner::get_preview_shot_color);
+  ClassDB::bind_method(D_METHOD("set_preview_shot_color", "mode"), &BulletSpawner::set_preview_shot_color);
+  ClassDB::bind_method(D_METHOD("get_preview_shot_color"), &BulletSpawner::get_preview_shot_color);
 
-    ClassDB::bind_method(D_METHOD("set_preview_extent", "mode"), &BulletSpawner::set_preview_extent);
-    ClassDB::bind_method(D_METHOD("get_preview_extent"), &BulletSpawner::get_preview_extent);
+  ClassDB::bind_method(D_METHOD("set_preview_extent", "mode"), &BulletSpawner::set_preview_extent);
+  ClassDB::bind_method(D_METHOD("get_preview_extent"), &BulletSpawner::get_preview_extent);
 
-    ClassDB::bind_method(D_METHOD("set_preview_arc_points", "mode"), &BulletSpawner::set_preview_arc_points);
-    ClassDB::bind_method(D_METHOD("get_preview_arc_points"), &BulletSpawner::get_preview_arc_points);
+  ClassDB::bind_method(D_METHOD("set_preview_arc_points", "mode"), &BulletSpawner::set_preview_arc_points);
+  ClassDB::bind_method(D_METHOD("get_preview_arc_points"), &BulletSpawner::get_preview_arc_points);
 
-    ClassDB::bind_method(D_METHOD("set_relay_autoconnect", "allow_incoming"), &BulletSpawner::set_relay_autoconnect);
-	ClassDB::bind_method(D_METHOD("get_relay_autoconnect"), &BulletSpawner::get_relay_autoconnect);
+  ClassDB::bind_method(D_METHOD("set_relay_autoconnect", "allow_incoming"), &BulletSpawner::set_relay_autoconnect);
+  ClassDB::bind_method(D_METHOD("get_relay_autoconnect"), &BulletSpawner::get_relay_autoconnect);
 
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autofire"), "set_autofire", "get_autofire");
-    ADD_PROPERTY(PropertyInfo(Variant::INT, "interval_frames", PROPERTY_HINT_RANGE, "1,300,or_greater"), "set_interval_frames", "get_interval_frames");
-    ADD_PROPERTY(PropertyInfo(Variant::INT, "shot_count", PROPERTY_HINT_RANGE, "1,100,or_greater"), "set_shot_count", "get_shot_count");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "radius", PROPERTY_HINT_RANGE, "0,500,0.01,or_greater"), "set_radius", "get_radius");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "arc_width", PROPERTY_HINT_RANGE, "", PROPERTY_USAGE_NOEDITOR), "set_arc_width", "get_arc_width");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "arc_width_degrees", PROPERTY_HINT_RANGE, "0,360,0.1,or_lesser,or_greater", PROPERTY_USAGE_EDITOR), "set_arc_width_degrees", "get_arc_width_degrees");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "arc_rotation", PROPERTY_HINT_RANGE, "", PROPERTY_USAGE_NOEDITOR), "set_arc_rotation", "get_arc_rotation");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "arc_rotation_degrees", PROPERTY_HINT_RANGE, "-360,360,0.1,or_lesser,or_greater", PROPERTY_USAGE_EDITOR), "set_arc_rotation_degrees", "get_arc_rotation_degrees");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "arc_offset", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_arc_offset", "get_arc_offset");
-    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "bullet_type", PROPERTY_HINT_RESOURCE_TYPE, "BulletType"), "set_bullet_type", "get_bullet_type");
-    ADD_GROUP("Aim", "aim_");
-    ADD_PROPERTY(PropertyInfo(Variant::INT, "aim_mode", PROPERTY_HINT_ENUM, "Radial,Uniform,Relative Target,Global Target"), "set_aim_mode", "get_aim_mode");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "aim_angle", PROPERTY_HINT_RANGE, "", PROPERTY_USAGE_NOEDITOR), "set_aim_angle", "get_aim_angle");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "aim_angle_degrees", PROPERTY_HINT_RANGE, "-360,360,0.1,or_lesser,or_greater", PROPERTY_USAGE_EDITOR), "set_aim_angle_degrees", "get_aim_angle_degrees");
-    ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "aim_target_position"), "set_aim_target_position", "get_aim_target_position");
-    ADD_GROUP("Scatter", "scatter_");
-    ADD_PROPERTY(PropertyInfo(Variant::INT, "scatter_mode", PROPERTY_HINT_ENUM, "None,Bullet,Volley"), "set_scatter_mode", "get_scatter_mode");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "scatter_range", PROPERTY_HINT_RANGE, "", PROPERTY_USAGE_NOEDITOR), "set_scatter_range", "get_scatter_range");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "scatter_range_degrees", PROPERTY_HINT_RANGE, "0,360,0.1,or_lesser,or_greater", PROPERTY_USAGE_EDITOR), "set_scatter_range_degrees", "get_scatter_range_degrees");
-    ADD_GROUP("Pattern", "");
-    ADD_PROPERTY(PropertyInfo(Variant::INT, "pattern_mode", PROPERTY_HINT_ENUM, "All,Manual"), "set_pattern_mode", "get_pattern_mode");
-    ADD_PROPERTY(PropertyInfo(Variant::POOL_INT_ARRAY, "active_shot_indices"), "set_active_shot_indices", "get_active_shot_indices");
-    ADD_GROUP("Preview", "preview_");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "preview_visible_in_game"), "set_preview_visible_in_game", "get_preview_visible_in_game");
-    ADD_PROPERTY(PropertyInfo(Variant::COLOR, "preview_color"), "set_preview_color", "get_preview_color");
-    ADD_PROPERTY(PropertyInfo(Variant::COLOR, "preview_shot_color"), "set_preview_shot_color", "get_preview_shot_color");
-    ADD_PROPERTY(PropertyInfo(Variant::REAL, "preview_extent", PROPERTY_HINT_RANGE, "0,500,0.1,or_greater"), "set_preview_extent", "get_preview_extent");
-    ADD_PROPERTY(PropertyInfo(Variant::INT, "preview_arc_points", PROPERTY_HINT_RANGE, "2,128,or_greater"), "set_preview_arc_points", "get_preview_arc_points");
-    ADD_GROUP("Relay", "relay_");
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "relay_autoconnect"), "set_relay_autoconnect", "get_relay_autoconnect");
+  ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autofire"), "set_autofire", "get_autofire");
+  ADD_PROPERTY(PropertyInfo(Variant::INT, "interval_frames", PROPERTY_HINT_RANGE, "1,300,or_greater"), "set_interval_frames", "get_interval_frames");
+  ADD_PROPERTY(PropertyInfo(Variant::INT, "shot_count", PROPERTY_HINT_RANGE, "1,100,or_greater"), "set_shot_count", "get_shot_count");
+  ADD_PROPERTY(PropertyInfo(Variant::REAL, "radius", PROPERTY_HINT_RANGE, "0,500,0.01,or_greater"), "set_radius", "get_radius");
+  ADD_PROPERTY(PropertyInfo(Variant::REAL, "arc_width", PROPERTY_HINT_RANGE, "", PROPERTY_USAGE_NOEDITOR), "set_arc_width", "get_arc_width");
+  ADD_PROPERTY(PropertyInfo(Variant::REAL, "arc_width_degrees", PROPERTY_HINT_RANGE, "0,360,0.1,or_lesser,or_greater", PROPERTY_USAGE_EDITOR), "set_arc_width_degrees", "get_arc_width_degrees");
+  ADD_PROPERTY(PropertyInfo(Variant::REAL, "arc_rotation", PROPERTY_HINT_RANGE, "", PROPERTY_USAGE_NOEDITOR), "set_arc_rotation", "get_arc_rotation");
+  ADD_PROPERTY(PropertyInfo(Variant::REAL, "arc_rotation_degrees", PROPERTY_HINT_RANGE, "-360,360,0.1,or_lesser,or_greater", PROPERTY_USAGE_EDITOR), "set_arc_rotation_degrees", "get_arc_rotation_degrees");
+  ADD_PROPERTY(PropertyInfo(Variant::REAL, "arc_offset", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_arc_offset", "get_arc_offset");
+  ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "bullet_type", PROPERTY_HINT_RESOURCE_TYPE, "BulletType"), "set_bullet_type", "get_bullet_type");
+  ADD_GROUP("Aim", "aim_");
+  ADD_PROPERTY(PropertyInfo(Variant::INT, "aim_mode", PROPERTY_HINT_ENUM, "Radial,Uniform,Relative Target,Global Target"), "set_aim_mode", "get_aim_mode");
+  ADD_PROPERTY(PropertyInfo(Variant::REAL, "aim_angle", PROPERTY_HINT_RANGE, "", PROPERTY_USAGE_NOEDITOR), "set_aim_angle", "get_aim_angle");
+  ADD_PROPERTY(PropertyInfo(Variant::REAL, "aim_angle_degrees", PROPERTY_HINT_RANGE, "-360,360,0.1,or_lesser,or_greater", PROPERTY_USAGE_EDITOR), "set_aim_angle_degrees", "get_aim_angle_degrees");
+  ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "aim_target_position"), "set_aim_target_position", "get_aim_target_position");
+  ADD_GROUP("Scatter", "scatter_");
+  ADD_PROPERTY(PropertyInfo(Variant::INT, "scatter_mode", PROPERTY_HINT_ENUM, "None,Bullet,Volley"), "set_scatter_mode", "get_scatter_mode");
+  ADD_PROPERTY(PropertyInfo(Variant::REAL, "scatter_range", PROPERTY_HINT_RANGE, "", PROPERTY_USAGE_NOEDITOR), "set_scatter_range", "get_scatter_range");
+  ADD_PROPERTY(PropertyInfo(Variant::REAL, "scatter_range_degrees", PROPERTY_HINT_RANGE, "0,360,0.1,or_lesser,or_greater", PROPERTY_USAGE_EDITOR), "set_scatter_range_degrees", "get_scatter_range_degrees");
+  ADD_GROUP("Pattern", "");
+  ADD_PROPERTY(PropertyInfo(Variant::INT, "pattern_mode", PROPERTY_HINT_ENUM, "All,Manual"), "set_pattern_mode", "get_pattern_mode");
+  ADD_PROPERTY(PropertyInfo(Variant::POOL_INT_ARRAY, "active_shot_indices"), "set_active_shot_indices", "get_active_shot_indices");
+  ADD_GROUP("Preview", "preview_");
+  ADD_PROPERTY(PropertyInfo(Variant::BOOL, "preview_visible_in_game"), "set_preview_visible_in_game", "get_preview_visible_in_game");
+  ADD_PROPERTY(PropertyInfo(Variant::COLOR, "preview_color"), "set_preview_color", "get_preview_color");
+  ADD_PROPERTY(PropertyInfo(Variant::COLOR, "preview_shot_color"), "set_preview_shot_color", "get_preview_shot_color");
+  ADD_PROPERTY(PropertyInfo(Variant::REAL, "preview_extent", PROPERTY_HINT_RANGE, "0,500,0.1,or_greater"), "set_preview_extent", "get_preview_extent");
+  ADD_PROPERTY(PropertyInfo(Variant::INT, "preview_arc_points", PROPERTY_HINT_RANGE, "2,128,or_greater"), "set_preview_arc_points", "get_preview_arc_points");
+  ADD_GROUP("Relay", "relay_");
+  ADD_PROPERTY(PropertyInfo(Variant::BOOL, "relay_autoconnect"), "set_relay_autoconnect", "get_relay_autoconnect");
 
-    ADD_SIGNAL(MethodInfo("volley_fired", PropertyInfo(Variant::OBJECT, "type", PROPERTY_HINT_RESOURCE_TYPE, "BulletType"), PropertyInfo(Variant::VECTOR2, "origin"), PropertyInfo(Variant::ARRAY, "volley")));
+  ADD_SIGNAL(MethodInfo("volley_fired", PropertyInfo(Variant::OBJECT, "type", PROPERTY_HINT_RESOURCE_TYPE, "BulletType"), PropertyInfo(Variant::VECTOR2, "origin"), PropertyInfo(Variant::ARRAY, "volley")));
 
-    BIND_ENUM_CONSTANT(ALL);
-    BIND_ENUM_CONSTANT(MANUAL);
+  BIND_ENUM_CONSTANT(ALL);
+  BIND_ENUM_CONSTANT(MANUAL);
 
-    BIND_ENUM_CONSTANT(RADIAL);
-    BIND_ENUM_CONSTANT(UNIFORM);
-    BIND_ENUM_CONSTANT(TARGET_RELATIVE);
-    BIND_ENUM_CONSTANT(TARGET_GLOBAL);
+  BIND_ENUM_CONSTANT(RADIAL);
+  BIND_ENUM_CONSTANT(UNIFORM);
+  BIND_ENUM_CONSTANT(TARGET_RELATIVE);
+  BIND_ENUM_CONSTANT(TARGET_GLOBAL);
 
-    BIND_ENUM_CONSTANT(NONE);
-    BIND_ENUM_CONSTANT(BULLET);
-    BIND_ENUM_CONSTANT(VOLLEY);
+  BIND_ENUM_CONSTANT(NONE);
+  BIND_ENUM_CONSTANT(BULLET);
+  BIND_ENUM_CONSTANT(VOLLEY);
 }
 
 //initialiser/terminator
 BulletSpawner::BulletSpawner() {
-    autofire = false;
-    interval_frames = 10;
-    shot_count = 1;
-    radius = 10.0;
-    arc_width = 0.0;
-    arc_rotation = 0.0;
-    arc_offset = 0.0;
-    aim_mode = RADIAL;
-    aim_angle = 0.0;
-    scatter_mode = NONE;
-    scatter_range = 0.0;
-    pattern_mode = ALL;
-    preview_visible_in_game = false;
-    preview_color = Color(0.0, 1.0, 0.0, 1.0); //green
-    preview_shot_color = Color(1.0, 1.0, 1.0, 1.0);
-    preview_arc_points = 32;
-    preview_extent = 50;
-    relay_autoconnect = true;
+  autofire = false;
+  interval_frames = 10;
+  shot_count = 1;
+  radius = 10.0;
+  arc_width = 0.0;
+  arc_rotation = 0.0;
+  arc_offset = 0.0;
+  aim_mode = RADIAL;
+  aim_angle = 0.0;
+  scatter_mode = NONE;
+  scatter_range = 0.0;
+  pattern_mode = ALL;
+  preview_visible_in_game = false;
+  preview_color = Color(0.0, 1.0, 0.0, 1.0); //green
+  preview_shot_color = Color(1.0, 1.0, 1.0, 1.0);
+  preview_arc_points = 32;
+  preview_extent = 50;
+  relay_autoconnect = true;
 }
 
 BulletSpawner::~BulletSpawner() {
-    
+
 }

--- a/bullet_spawner.h
+++ b/bullet_spawner.h
@@ -7,171 +7,171 @@
 #include "bullet_server_relay.h"
 
 class BulletSpawner : public Node2D{
-    GDCLASS(BulletSpawner, Node2D);
+  GDCLASS(BulletSpawner, Node2D);
 
 public:
-    enum PatternMode {
-        ALL,
-        MANUAL,
-    };
+  enum PatternMode {
+    ALL,
+    MANUAL,
+  };
 
-    enum AimMode {
-        RADIAL,
-        UNIFORM,
-        TARGET_RELATIVE,
-        TARGET_GLOBAL,
-    };
+  enum AimMode {
+    RADIAL,
+    UNIFORM,
+    TARGET_RELATIVE,
+    TARGET_GLOBAL,
+  };
 
-    enum ScatterMode {
-        NONE,
-        BULLET,
-        VOLLEY,
-    };
+  enum ScatterMode {
+    NONE,
+    BULLET,
+    VOLLEY,
+  };
 
 private:
-    bool autofire;
-    float _autofire_time;
-    int interval_frames;
+  bool autofire;
+  float _autofire_time;
+  int interval_frames;
 
-    int shot_count;
+  int shot_count;
 
-    float radius;
-    float arc_width;
-    float arc_rotation;
-    float arc_offset;
+  float radius;
+  float arc_width;
+  float arc_rotation;
+  float arc_offset;
 
-    Ref<BulletType> bullet_type;
+  Ref<BulletType> bullet_type;
 
-    AimMode aim_mode;
-    float aim_angle;
-    Vector2 aim_target_position;
+  AimMode aim_mode;
+  float aim_angle;
+  Vector2 aim_target_position;
 
-    ScatterMode scatter_mode;
-    float scatter_range;
+  ScatterMode scatter_mode;
+  float scatter_range;
 
-    PatternMode pattern_mode;
-    PoolIntArray active_shot_indices;
+  PatternMode pattern_mode;
+  PoolIntArray active_shot_indices;
 
-    bool preview_visible_in_game;
-    Color preview_color;
-    Color preview_shot_color;
-    float preview_extent;
-    int preview_arc_points;
+  bool preview_visible_in_game;
+  Color preview_color;
+  Color preview_shot_color;
+  float preview_extent;
+  int preview_arc_points;
 
-    bool relay_autoconnect;
+  bool relay_autoconnect;
 
-    Array _cached_volley;
-    bool _volley_changed;
+  Array _cached_volley;
+  bool _volley_changed;
 
-    Transform2D _previous_transform;
-    
-    Array _get_selected_shots(const Array &p_volley, const PoolIntArray &p_shot_indices) const;
+  Transform2D _previous_transform;
 
-    void _volley_change_notify();
+  Array _get_selected_shots(const Array &p_volley, const PoolIntArray &p_shot_indices) const;
 
-    Array _create_volley() const;
-    Vector2 _get_shot_position(const Vector2 &p_normal) const;
-    Vector2 _get_shot_direction(const Vector2 &p_position, const Vector2 &p_normal) const;
+  void _volley_change_notify();
 
-    int _get_unique_shot_count(bool p_include_scatter = false) const;
+  Array _create_volley() const;
+  Vector2 _get_shot_position(const Vector2 &p_normal) const;
+  Vector2 _get_shot_direction(const Vector2 &p_position, const Vector2 &p_normal) const;
 
-    void _draw_preview(const Color &p_border_col, const Color &p_shot_col);
-    Vector2 _get_outer_preview_point(const Vector2 &p_inner_point, const Vector2 &p_inner_normal, float p_extent) const;
-    void _draw_shot_lines(const Array &p_volley, float p_length, const Color &p_color);
+  int _get_unique_shot_count(bool p_include_scatter = false) const;
+
+  void _draw_preview(const Color &p_border_col, const Color &p_shot_col);
+  Vector2 _get_outer_preview_point(const Vector2 &p_inner_point, const Vector2 &p_inner_normal, float p_extent) const;
+  void _draw_shot_lines(const Array &p_volley, float p_length, const Color &p_color);
 
 protected:
-    static void _bind_methods();
-    void _notification(int p_what);
-    void _validate_property(PropertyInfo &property) const;
+  static void _bind_methods();
+  void _notification(int p_what);
+  void _validate_property(PropertyInfo &property) const;
 
 public:
-    bool can_fire() const;
+  bool can_fire() const;
 
-    void fire();
-    void fire_shots(const PoolIntArray &p_shot_indices);
+  void fire();
+  void fire_shots(const PoolIntArray &p_shot_indices);
 
-    Array get_volley();
-    Array get_scattered_volley();
+  Array get_volley();
+  Array get_scattered_volley();
 
-    void set_autofire(bool p_enabled);
-    bool get_autofire() const;
+  void set_autofire(bool p_enabled);
+  bool get_autofire() const;
 
-    void set_interval_frames(int p_interval);
-    int get_interval_frames() const;
+  void set_interval_frames(int p_interval);
+  int get_interval_frames() const;
 
-    void set_shot_count(int p_count);
-    int get_shot_count() const;
+  void set_shot_count(int p_count);
+  int get_shot_count() const;
 
-    void set_radius(float p_radius);
-    float get_radius() const;
+  void set_radius(float p_radius);
+  float get_radius() const;
 
-    void set_arc_width(float p_radians);
-    float get_arc_width() const;
+  void set_arc_width(float p_radians);
+  float get_arc_width() const;
 
-    void set_arc_width_degrees(float p_degrees);
-    float get_arc_width_degrees() const;
+  void set_arc_width_degrees(float p_degrees);
+  float get_arc_width_degrees() const;
 
-    void set_arc_rotation(float p_radians);
-    float get_arc_rotation() const;
+  void set_arc_rotation(float p_radians);
+  float get_arc_rotation() const;
 
-    void set_arc_rotation_degrees(float p_degrees);
-    float get_arc_rotation_degrees() const;
+  void set_arc_rotation_degrees(float p_degrees);
+  float get_arc_rotation_degrees() const;
 
-    void set_arc_offset(float p_offset);
-    float get_arc_offset() const;
+  void set_arc_offset(float p_offset);
+  float get_arc_offset() const;
 
-    void set_bullet_type(const Ref<BulletType> &p_type);
-    Ref<BulletType> get_bullet_type() const;
+  void set_bullet_type(const Ref<BulletType> &p_type);
+  Ref<BulletType> get_bullet_type() const;
 
-    void set_aim_mode(AimMode p_mode);
-    AimMode get_aim_mode() const;
+  void set_aim_mode(AimMode p_mode);
+  AimMode get_aim_mode() const;
 
-    void set_aim_angle(float p_radians);
-    float get_aim_angle() const;
+  void set_aim_angle(float p_radians);
+  float get_aim_angle() const;
 
-    void set_aim_angle_degrees(float p_degrees);
-    float get_aim_angle_degrees() const;
+  void set_aim_angle_degrees(float p_degrees);
+  float get_aim_angle_degrees() const;
 
-    void set_aim_target_position(const Vector2 &p_position);
-    Vector2 get_aim_target_position() const;
+  void set_aim_target_position(const Vector2 &p_position);
+  Vector2 get_aim_target_position() const;
 
-    void set_scatter_mode(ScatterMode p_mode);
-    ScatterMode get_scatter_mode() const;
+  void set_scatter_mode(ScatterMode p_mode);
+  ScatterMode get_scatter_mode() const;
 
-    void set_scatter_range(float p_radians);
-    float get_scatter_range() const;
+  void set_scatter_range(float p_radians);
+  float get_scatter_range() const;
 
-    void set_scatter_range_degrees(float p_degrees);
-    float get_scatter_range_degrees() const;
+  void set_scatter_range_degrees(float p_degrees);
+  float get_scatter_range_degrees() const;
 
-    void set_pattern_mode(PatternMode p_mode);
-    PatternMode get_pattern_mode() const;
+  void set_pattern_mode(PatternMode p_mode);
+  PatternMode get_pattern_mode() const;
 
-    void set_active_shot_indices(const PoolIntArray &p_points);
-    PoolIntArray get_active_shot_indices() const;
+  void set_active_shot_indices(const PoolIntArray &p_points);
+  PoolIntArray get_active_shot_indices() const;
 
-    void set_preview_visible_in_game(bool p_enabled);
-    bool get_preview_visible_in_game() const;
+  void set_preview_visible_in_game(bool p_enabled);
+  bool get_preview_visible_in_game() const;
 
-    void set_preview_color(const Color &p_color);
-    Color get_preview_color() const;
+  void set_preview_color(const Color &p_color);
+  Color get_preview_color() const;
 
-    void set_preview_shot_color(const Color &p_color);
-    Color get_preview_shot_color() const;
+  void set_preview_shot_color(const Color &p_color);
+  Color get_preview_shot_color() const;
 
-    void set_preview_extent(float p_length);
-    float get_preview_extent() const;
+  void set_preview_extent(float p_length);
+  float get_preview_extent() const;
 
-    void set_preview_arc_points(int p_count);
-    int get_preview_arc_points() const;
+  void set_preview_arc_points(int p_count);
+  int get_preview_arc_points() const;
 
-    void set_relay_autoconnect(bool p_enabled);
+  void set_relay_autoconnect(bool p_enabled);
 	bool get_relay_autoconnect() const;
 
-    String get_configuration_warning() const;
+  String get_configuration_warning() const;
 
-    BulletSpawner();
-    ~BulletSpawner();
+  BulletSpawner();
+  ~BulletSpawner();
 };
 
 VARIANT_ENUM_CAST(BulletSpawner::PatternMode)

--- a/bullet_type.cpp
+++ b/bullet_type.cpp
@@ -309,8 +309,8 @@ void BulletType::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "custom_data"), "set_custom_data", "get_custom_data");
 
 	BIND_ENUM_CONSTANT(NONE);
-    BIND_ENUM_CONSTANT(SIN);
-    BIND_ENUM_CONSTANT(COS);
+  BIND_ENUM_CONSTANT(SIN);
+  BIND_ENUM_CONSTANT(COS);
 }
 
 BulletType::BulletType() {


### PR DESCRIPTION
Added functions `get_live_bullets` and `get_live_bullet_positions` to `BulletServer`.

`get_live_bullets` returns a copy of the array of live bullets belonging to the bullet server. It returns a copy of the array instead of a reference to the array itself so that their order cannot be changed. You can use this to access all currently live bullets in case you wish to apply some kind of change in behaviour. If you wish to delete any bullets accessed this way, please use `pop`, as normal.

`get_live_bullet_positions` returns an array containing the Vector2 positions of all live bullets on the server. Useful if you wish to clear bullets and apply some kind of effect at the positions they were at. Gives the same result as calling `get_live_bullets` and then calling `get_position` for each returned bullet, but is more optimized.

Resolves #21 