### PR TITLE
Fix mutex error during compile

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -13,7 +13,6 @@ sources = [
 
 module_env = env.Clone()
 module_env.Append(CCFLAGS=['-O2'])
-module_env.Append(CXXFLAGS=['-std=c++11'])
 
 if ARGUMENTS.get('qurobullet_shared', 'no') == 'yes':
     # Shared lib compilation


### PR DESCRIPTION
This quick PR removes a bad C++ library selection from SCsub that was causing compile errors due to `mutex` not being defined.

Resolves #31 